### PR TITLE
Views, URLs for admin auth

### DIFF
--- a/authentication/admin.py
+++ b/authentication/admin.py
@@ -8,4 +8,9 @@ from .models import *
 # register Merchant model
 # NOTE: don't register MerchantManager
 # - it's not a model but a (helper) custom manager class that handles the creation of user instances
-admin.site.register(Merchant)
+# The Django admin site was not displaying the merchant_id
+# - add it to the admin interface
+@admin.register(Merchant)
+class MerchantAdmin(admin.ModelAdmin):    
+    readonly_fields = ('merchant_id',)
+    

--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -98,6 +98,7 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
     username_field = 'email'
 
     # custom method to enhance JWT token with additional claims
+    # https://django-rest-framework-simplejwt.readthedocs.io/en/latest/customizing_token_claims.html#customizing-token-claims
     @classmethod
     def get_token(cls, user):
         """Generate JWT token with custom claims for the superuser merchant.

--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -1,6 +1,15 @@
+# import path for URL pattern routing in Django
 from django.urls import path
-from .views import MerchantCreateView
 
+# import AdminView class from views.py in the current directory
+from .views import AdminView
+
+########################################################################################################################
+
+# add url to superuser post method
+# add url to superuser get method
+# don't specify method -> APIView automatically maps HTTP methods (POST, GET) to corresponding class methods with as_view()
 urlpatterns = [
-    path('api/v1/merchants', MerchantCreateView.as_view(), name='create-merchant'),
+    path('api/v1/admins/', AdminView.as_view(), name='create_superuser'), 
+    path('api/v1/admins/<uuid:merchant_id>/', AdminView.as_view(), name='get_superuser'),    
 ]

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -33,6 +33,8 @@ from .serializers import CustomTokenObtainPairSerializer
 
 # create a custom view that inherits from DRF's built-in token view to generate a JWT token with custom claims
 # - uses custom serializer for email-based authentication & add custom custom claims 
+# keep the custom JWT setting local to the auth app, instead of doing it in settings.py making it global
+# https://django-rest-framework-simplejwt.readthedocs.io/en/latest/customizing_token_claims.html#customizing-token-claims
 class CustomTokenObtainPairView(TokenObtainPairView):
     # specify the custom serializer class that defines token customisations
     serializer_class = CustomTokenObtainPairSerializer

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -1,9 +1,129 @@
 from django.shortcuts import render
 
-from rest_framework import generics
-from .models import Merchant
-from .serializers import MerchantSerializer
+# API view allows for message customisation without overriding methods
+# using it since there are 2 endpoints: create, retrieve
+from rest_framework.views import APIView
 
-class MerchantCreateView(generics.CreateAPIView):
-    queryset = Merchant.objects.all()
-    serializer_class = MerchantSerializer
+# handle API responses with proper formatting
+from rest_framework.response import Response
+
+# provide permission classes & HTTP status codes for API endpoints
+# https://www.django-rest-framework.org/tutorial/3-class-based-views/#using-generic-class-based-views
+from rest_framework import permissions, status
+
+# use JWT token-based authentication
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+# import Merchant model from the current directory
+from .models import Merchant
+
+# import serializer for superuser (Admin) user operations
+from .serializers import AdminSerializer
+
+# import Django's exception for handling objects that do not exist
+from django.core.exceptions import ObjectDoesNotExist 
+
+# import JWT token view to generate a token
+from rest_framework_simplejwt.views import TokenObtainPairView
+
+# import custom serializer for a custom view to obtain a token 
+from .serializers import CustomTokenObtainPairSerializer
+
+###############################################################################################################
+
+# create a custom view that inherits from DRF's built-in token view to generate a JWT token with custom claims
+# - uses custom serializer for email-based authentication & add custom custom claims 
+class CustomTokenObtainPairView(TokenObtainPairView):
+    # specify the custom serializer class that defines token customisations
+    serializer_class = CustomTokenObtainPairSerializer
+
+# a class to create & retrieve superusers
+class AdminView(APIView):
+    # set JWT as the authentication method for this view (needs a valid token in request header)
+    authentication_classes = [JWTAuthentication]
+    # check that is_staff=True with Django REST Framework's built-in permission class
+    permission_classes = [permissions.IsAdminUser]
+
+    # a method to carry out superuser creation
+    def post(self, request):
+        """Handle the POST request to create a new superuser.
+
+        :param request: HTTP request containing admin data
+        :type request: rest_framework.request.Request
+        :return: Response with created superuser data or error message
+        :rtype: rest_framework.response.Response
+        """
+        # create an instance of AdminSerializer with the data from the HTTP POST request
+        serializer = AdminSerializer(data=request.data)
+
+        # check if the submitted data passes all validation rules defined in serializer
+        if serializer.is_valid():
+            # save the superuser
+            # ensure only superadmins get created
+            serializer.save(role='superadmin', is_staff=True, is_superuser=True)
+
+            # return a response with a message if the Superadmin was created        
+            return Response(
+                {
+                    "status": "success",
+                    "code": 201,
+                    "message": "Successfully added a Superadmin",
+                    "data": serializer.data,                
+                },            
+                status=status.HTTP_201_CREATED,             
+                )    
+        
+        # return a response with an unsuccessful message if the Superadmin was not created        
+        return Response(
+            {
+                "status": "error",
+                "code": 400,
+                "message": "Unsuccessful creating a Superadmin with invalid data",                
+                "data": serializer.data,                
+            },            
+            status=status.HTTP_400_BAD_REQUEST,             
+            )
+    
+    # a method to retrieve a Superadmin
+    def get(self, request, merchant_id=None):
+        """Retrieve a Superadmin by their merchant_id.
+
+        :param request: HTTP request object
+        :type request: rest_framework.request.Request
+        :param merchant_id: Unique identifier for merchant, defaults to None
+        :type merchant_id: str, optional
+        :return: Response with superuser data or error message
+        :rtype: rest_framework.response.Response
+        """
+        # use defensive programming with try-except blocks to retrieve a superuser
+        try:
+            # get the superadmin object
+            # if the superadmin does not exist, return a 404 error
+            superadmin = Merchant.objects.get(merchant_id=merchant_id, is_superuser=True)
+
+            # serialize the superadmin object
+            serializer = AdminSerializer(superadmin)
+
+            # return a response with the serialized data
+            return Response(
+                {
+                    "status": "success",
+                    "code": 200,
+                    "message": f"Successfully retrieved the Superadmin merchant with ID: {merchant_id}.",
+                    "data": serializer.data,
+                },
+                status=status.HTTP_200_OK,
+                )
+        
+        except ObjectDoesNotExist:
+            # return a response with a message if the Superadmin does not exist
+            return Response(
+                {
+                    "status": "error",
+                    "code": 404,
+                    "message": "A Superadmin with this merchant ID does not exist.",
+                    "data": None,
+                },
+                status=status.HTTP_404_NOT_FOUND,
+                )
+

--- a/payments/models.py
+++ b/payments/models.py
@@ -2,7 +2,7 @@ from django.db import models
 
 # Create your models here.
 import uuid
-from authentication.models import User
+from authentication.models import Merchant
 
 class PaymentGateway(models.Model):
     gateway_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -16,7 +16,7 @@ class PaymentGateway(models.Model):
 class MerchantPaymentGateway(models.Model):
     gateway_payment_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     gateway = models.ForeignKey(PaymentGateway, on_delete=models.CASCADE)
-    merchant = models.ForeignKey(User, on_delete=models.CASCADE, limit_choices_to={'role': 'merchant'})
+    merchant = models.ForeignKey(Merchant, on_delete=models.CASCADE, limit_choices_to={'role': 'merchant'})
     status = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/pedmonie/settings.py
+++ b/pedmonie/settings.py
@@ -82,8 +82,9 @@ REST_FRAMEWORK = {
 
 # JWT settings
 # https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html#settings
+# set token lifetime
 SIMPLE_JWT = {
-    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=5),
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=15),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
     "AUTH_HEADER_TYPES": ("Bearer",),
     "USER_ID_FIELD": "merchant_id", # use merchant_id instead of id

--- a/pedmonie/settings.py
+++ b/pedmonie/settings.py
@@ -71,6 +71,9 @@ ROOT_URLCONF = 'pedmonie.urls'
 # use JWT authentication for API requests
 # - https://django-rest-framework-simplejwt.readthedocs.io/en/latest/getting_started.html#project-configuration
 # require authentication for all views by default
+# add versioning globally
+# https://www.django-rest-framework.org/api-guide/versioning/#configuring-the-versioning-scheme
+# https://www.django-rest-framework.org/api-guide/versioning/#other-versioning-settings
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
@@ -78,6 +81,10 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning', # request.version should return 1
+    'DEFAULT_VERSION': 'v1', # DRF expects version numbers without prefixes e.g. 'v', else it would duplicate into /api/vv1/
+    'ALLOWED_VERSIONS': ['v1'],
+    'VERSION_PARAM': 'version',
 }
 
 # JWT settings

--- a/pedmonie/settings.py
+++ b/pedmonie/settings.py
@@ -90,6 +90,7 @@ REST_FRAMEWORK = {
 # JWT settings
 # https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html#settings
 # set token lifetime
+# https://django-rest-framework-simplejwt.readthedocs.io/en/latest/customizing_token_claims.html#customizing-token-claims
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=15),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=1),

--- a/pedmonie/urls.py
+++ b/pedmonie/urls.py
@@ -17,10 +17,26 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
+# import built-in views 
+# - TokenObtainPairView to handle login with username + password & return access + refresh tokens
+# - TokenRefreshView to accept expired refresh token & return new access token
+# https://django-rest-framework-simplejwt.readthedocs.io/en/latest/getting_started.html#project-configuration
+from rest_framework_simplejwt.views import TokenRefreshView
+
+# import custom view for JWT token generation in athentication app one level up in the directory
+from ..authentication.views import CustomTokenObtainPairView
+
+#########################################################################################################################
+
+# add urls for apps
+# add url to login and return JWT access + refresh tokens
+# add url to accept expired JWT refresh token & return new JWT token
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('auth/', include('authentication.urls')),
+    path('', include('authentication.urls')),
     path('dashboard/', include('dashboard.urls')),
     path('wallets/', include('wallets.urls')),
     path('orders/', include('orders.urls')),
+    path('api/v1/token/', CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 ]


### PR DESCRIPTION
Address Issue #10 
Added JWT endpoints - their URLs are in the main urls.py
JWT setting are currently local to auth views
Added custom JWT serializer to resolve error for default id - now accepts merchant_id
Added views for JWT, admin get, admin post
Added urls for admin get, admin post