### PR TITLE
Update Django Models to Ensure Compatibility with Node Team's Primary Key Schema

### DIFF
--- a/authentication/models.py
+++ b/authentication/models.py
@@ -109,7 +109,7 @@ class Merchant(AbstractBaseUser, PermissionsMixin):
     # basic merchant info
     
     merchant_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    sn = models.CharField(max_length=50,unique=True, db_index=True, verbose_name="Serial Number", blank=True)
+    sn = models.AutoField(unique=True, db_index=True, verbose_name="Serial Number")
     
 
     # def __str__(self):
@@ -191,14 +191,6 @@ class Merchant(AbstractBaseUser, PermissionsMixin):
         :rtype: str
         """
         return f"({self.role}), {self.first_name} {self.last_name} {self.business_name}"
-    def save(self, *args, **kwargs):
-        if not self.sn:  # Only assign if 'sn' is empty
-            last_merchant = Merchant.objects.exclude(sn='').order_by(models.functions.Cast('sn', models.IntegerField()).desc()).first()
-            if last_merchant and last_merchant.sn.isdigit():
-                self.sn = str(int(last_merchant.sn) + 1)
-            else:
-                self.sn = "1"  # Start from 1 if no records exist
-        super().save(*args, **kwargs)
     
         
     

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -4,24 +4,12 @@ from authentication.models import Merchant
 
 class AuditLog(models.Model):
     log_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    sn = models.CharField(max_length=50,unique=True, db_index=True, verbose_name="Serial Number", blank=True)
+    sn = models.AutoField(unique=True, db_index=True, verbose_name="Serial Number")
     admin = models.ForeignKey(Merchant, on_delete=models.CASCADE, limit_choices_to={'role': 'superadmin'})  # Reference Merchant model
     action = models.TextField()  # Example: "Deleted a merchant account"
     createdAt = models.DateTimeField(auto_now_add=True)
     class Meta:
         db_table = 'auditlog'
-
-    
-    def save(self, *args, **kwargs):
-        if not self.sn:  # Only assign if 'sn' is empty
-            last_log = AuditLog.objects.exclude(sn='').order_by(models.functions.Cast('sn', models.IntegerField()).desc()).first()
-            if last_log and last_log.sn.isdigit():
-                self.sn = str(int(last_log.sn) + 1)
-            else:
-                self.sn = "1"  # Start from 1 if no records exist
-        super().save(*args, **kwargs)
-
-    
 
     
     def __str__(self):

--- a/orders/models.py
+++ b/orders/models.py
@@ -3,7 +3,7 @@ from authentication.models import Merchant
 import uuid
 
 class Order(models.Model):
-    sn = models.CharField(max_length=50,unique=True, db_index=True, verbose_name="Serial Number", blank=True)
+    sn = models.AutoField(unique=True, db_index=True, verbose_name="Serial Number")
     order_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     gateway_name = models.CharField(max_length=50)
     merchant = models.ForeignKey(Merchant, on_delete=models.PROTECT, related_name='orders')
@@ -17,14 +17,6 @@ class Order(models.Model):
     createdAt = models.DateTimeField(auto_now_add=True)
     updatedAt = models.DateTimeField(auto_now=True)
 
-    def save(self, *args, **kwargs):
-        if not self.sn:  # Only assign if 'sn' is empty
-            last_order = Order.objects.exclude(sn='').order_by(models.functions.Cast('sn', models.IntegerField()).desc()).first()
-            if last_order and last_order.sn.isdigit():
-                self.sn = str(int(last_order.sn) + 1)
-            else:
-                self.sn = "1"  # Start from 1 if no records exist
-        super().save(*args, **kwargs)
 
     class Meta:
         ordering = ['createdAt']

--- a/payments/models.py
+++ b/payments/models.py
@@ -6,7 +6,7 @@ class PaymentGateway(models.Model):
     """
     Model for storing available payment gateways.
     """
-    sn = models.CharField(max_length=50,unique=True, db_index=True, verbose_name="Serial Number", blank=True)
+    sn = models.AutoField(unique=True, db_index=True, verbose_name="Serial Number")
     gateway_id = models.UUIDField(primary_key=True, default=uuid.uuid4, unique=True, editable=False)
     gateway_name = models.CharField(max_length=100, unique=True)
     gateway_logo = models.ImageField(upload_to="gateway_logo/", null=True, blank=True)
@@ -15,14 +15,6 @@ class PaymentGateway(models.Model):
     updatedAt = models.DateTimeField(auto_now=True)
 
 
-    def save(self, *args, **kwargs):
-        if not self.sn:  # Only assign if 'sn' is empty
-            last_PG = PaymentGateway.objects.exclude(sn='').order_by(models.functions.Cast('sn', models.IntegerField()).desc()).first()
-            if last_PG and last_PG.sn.isdigit():
-                self.sn = str(int(last_PG.sn) + 1)
-            else:
-                self.sn = "1"  # Start from 1 if no records exist
-        super().save(*args, **kwargs)
 
     class Meta:
         db_table = "paymentgateways"  # Matches Sequelize table name
@@ -35,7 +27,7 @@ class MerchantPaymentGateway(models.Model):
     """
     Model for storing a merchant's enabled payment gateways.
     """
-    sn = models.AutoField(primary_key=True)  # Matches Sequelize's `autoIncrement: true`
+    sn = models.AutoField(primary_key=True, unique=True, db_index=True, verbose_name="Serial Number")  # Matches Sequelize's `autoIncrement: true`
     merchant = models.ForeignKey(Merchant, on_delete=models.CASCADE, related_name='merchant_payment_gateway')
     payment_gateways = models.JSONField(blank=False)  # Store JSON data for active payment gateways
     createdAt = models.DateTimeField(auto_now_add=True)

--- a/transactions/models.py
+++ b/transactions/models.py
@@ -7,7 +7,7 @@ from orders.models import Order
 
 class Transaction(models.Model):
     transaction_id = models.UUIDField(primary_key=True)
-    sn = models.CharField(max_length=50,unique=True, db_index=True, verbose_name="Serial Number", blank=True)
+    sn = models.AutoField(unique=True, db_index=True, verbose_name="Serial Number")
     order = models.ForeignKey(Order, on_delete=models.CASCADE, related_name='order_transactions')
     merchant = models.ForeignKey(Merchant, on_delete=models.CASCADE, related_name='transactions')
     gateway_name = models.CharField(max_length=50)
@@ -28,13 +28,5 @@ class Transaction(models.Model):
 
     def __str__(self):
         return f"Transaction {self.transaction_id} - {self.status}"
-    
-    def save(self, *args, **kwargs):
-        if not self.sn:  # Only assign if 'sn' is empty
-            last_transaction = Transaction.objects.exclude(sn='').order_by(models.functions.Cast('sn', models.IntegerField()).desc()).first()
-            if last_transaction and last_transaction.sn.isdigit():
-                self.sn = str(int(last_transaction.sn) + 1)
-            else:
-                self.sn = "1"  # Start from 1 if no records exist
-        super().save(*args, **kwargs)
+
         


### PR DESCRIPTION
# Description

The current implementation of the sn field in our Django models uses a CharField with custom logic for auto-increment. However, to ensure compatibility with the Node team and the remote MySQL database, we need to update the sn field to an AutoField type, which is an auto-incrementing integer.

# Task:

Update the sn field in the Wallet model to use AutoField.

Remove the custom save method responsible for managing the sn field.

Verify that the sn field in the Wallet model is indexed and unique.

Ensure that the updated field in the MySQL database is of type INT with the AUTO_INCREMENT attribute.

Repeat the same updates for the Withdrawal model to ensure consistency.

Test the models to ensure proper functionality and compatibility with the Node team's schema.


# Affected Tables:

- Authentication
- Dashboard
- Orders
- Transactions
- Wallets
- Withdrawal


#51 