### PR TITLE
Rename merchant_id field to merchant in SupportTicket model for clarity

### DIFF
--- a/support/models.py
+++ b/support/models.py
@@ -7,7 +7,7 @@ from authentication.models import Merchant
 class SupportTicket(models.Model):
     ticket_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     sn = models.IntegerField(unique=True, db_index=True, verbose_name="Serial Number")
-    merchant_id = models.ForeignKey(Merchant, on_delete=models.CASCADE, limit_choices_to={'role': 'merchant'}, related_name='support_ticket')
+    merchant = models.ForeignKey(Merchant, on_delete=models.CASCADE, limit_choices_to={'role': 'merchant'}, related_name='support_ticket')
     status = models.CharField(max_length=20, choices=[('pending', 'Pending'), ('resolved', 'Resolved')], default='pending')
     description = models.TextField()
     createdAt = models.DateTimeField(auto_now_add=True)


### PR DESCRIPTION
**Description**

A quick error fix on the SupportTicket model to resolve the Fielderror

![Image](https://github.com/user-attachments/assets/330451a9-9bf0-4435-ad96-5aaaeddc910d)

**What was done**
Changed `merchant_id` in `SupportTicket class` in the support django app model, 
to `merchant`

closes #59 